### PR TITLE
Warn against uploading zipped GeoJSON

### DIFF
--- a/sotmus-2018-heatmaps/README.md
+++ b/sotmus-2018-heatmaps/README.md
@@ -139,7 +139,7 @@ Next, bring the GeoJSON data into Studio by importing it as a tileset. Switch to
 
 Example: https://www.mapbox.com/studio/tilesets/1ec5.5dxtwy7u/
 
-**Note:** Metro Detroit has enough building data that the GeoJSON exceeds the 5&nbsp;MB limit for uploads within Studio. To get around this limitation, use the [Uploads API](https://www.mapbox.com/api-documentation/#uploads), which has a more generous limit of 1&nbsp;GB for GeoJSON files.
+**Note:** If you downloaded one of the ZIP files above, unzip it before dragging it into Studio. Otherwise, Studio assumes it’s a shapefile and enforces a 5&nbsp;MB file size limit, instead of the more generous limit of 1&nbsp;GB for GeoJSON files.
 
 Now that we have more data, let’s go through the motions of adding a heatmap layer again. Once again, choose a layer in a style, but this time the layers come from the tileset we just uploaded.
 


### PR DESCRIPTION
It turns out the 5&nbsp;MB limit is for shapefiles, not GeoJSON. Workshop participants were running into this limit because they had tried to upload the zipped GeoJSON files provided in this writeup instead of first unzipping them. Studio assumes ZIP files are shapefiles, even if they happen to contain GeoJSON files.

Thanks to @mapsam @samanpwbb @brsbl for helping me diagnose this problem.